### PR TITLE
Update 64.md: typos, spelling

### DIFF
--- a/64.md
+++ b/64.md
@@ -4,8 +4,8 @@ NIP-64
 Trust Score
 -----------
 
-A trust score is a public way for an user to assign a quantifiable level of trust to a nostr identity or event.
-It may be general or scoped to a specifc topic.
+A trust score is a public way for a user to assign a quantifiable level of trust to a nostr identity or event.
+It may be general or scoped to a specific topic.
 
 ## Event Structure
 
@@ -37,13 +37,13 @@ After the tag value, there may be variadic fields with key and value separated b
 #### Review
 
 - **Key**: `re`
-- **Value**: Sentiment prefix, collon (`:`) separator and the actual review text.
-The prefix denote a postive review (`+`), a negative review (`-`) or a neutral one (`?`).
+- **Value**: Sentiment prefix, colon (`:`) separator and the actual review text.
+The prefix denote a positive review (`+`), a negative review (`-`) or a neutral one (`?`).
 
 The `?` prefix is usually assigned for free form user generated reviews. On the other hand, `+` and `-` are usually
 related to clickable fixed options made available by a client.
 
-There may be any number of reviews. It should have at max one review prefixed with `?`.
+There may be any number of reviews. It should have at most one review prefixed with `?`.
 
 Example: `["T", "2", "re ?:This is a review"]`
 
@@ -74,7 +74,7 @@ Example ranking systems:
 
 ## Example Events
 
-Assinging trust score to a pubkey on several topics:
+Assigning trust score to a pubkey on several topics:
 
 ```js
 {
@@ -110,7 +110,7 @@ Assinging trust score to an app:
 ## Filtering
 
 The reason why the rating score (integer value) has few possible values and is placed together with the topic name
-is for letting clients filter on relays by both data e.g. to easily fetch good or bad users on specifc topics.
+is for letting clients filter on relays by both data e.g. to easily fetch good or bad users on specific topics.
 
 Example filters:
 


### PR DESCRIPTION
- Corrected "an user" to "a user"
- Fixed spelling errors: "specifc" to "specific", "collon" to "colon", "postive" to "positive", and "Assinging" to "Assigning"
- Improved clarity in phrasing for better understanding